### PR TITLE
Remove text causing false positives in security scans

### DIFF
--- a/src/test/java/io/jenkins/plugins/ksm/MockConfig.java
+++ b/src/test/java/io/jenkins/plugins/ksm/MockConfig.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.ksm;
+
+import com.keepersecurity.secretsManager.core.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class MockConfig {
+
+    private String makeRandomString(int length) {
+        String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+                          "abcdefghijklmnopqrstuvwzyz" +
+                          "0123456789";
+        StringBuilder sb = new StringBuilder();
+        Random random = new Random();
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(alphabet.length());
+            char randomChar = alphabet.charAt(index);
+            sb.append(randomChar);
+        }
+        return sb.toString();
+    }
+
+    public HashMap<String, String> makeConfig() throws Exception {
+
+        HashMap<String, String> config = new HashMap<>();
+
+        String hostname = makeRandomString(10) + ".com";
+        String tokenRndStr = makeRandomString(32) + ".com";
+        String token = Base64.getUrlEncoder()
+                .encodeToString(tokenRndStr.getBytes(StandardCharsets.UTF_8));
+
+        LocalConfigStorage storage = new LocalConfigStorage();
+        try {
+            SecretsManager.initializeStorage(storage, token, hostname);
+        } catch (Exception e) {
+            throw new Exception("Cannot mock config: " + e.getMessage());
+        }
+
+        String appKeyRandomString = makeRandomString(32);
+        String appKey = Base64.getEncoder()
+                .encodeToString(appKeyRandomString.getBytes(StandardCharsets.UTF_8));
+
+        config.put("hostname", hostname);
+        config.put("appKey", appKey);
+        config.put("clientId", storage.getString(SecretsManager.KEY_CLIENT_ID));
+        config.put("privateKey", storage.getString(SecretsManager.KEY_PRIVATE_KEY));
+        config.put("serverPublicKeyId", storage.getString(SecretsManager.KEY_SERVER_PUBIC_KEY_ID));
+
+        return config;
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapperTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapperTest.java
@@ -12,6 +12,7 @@ import hudson.tasks.Shell;
 import hudson.util.Secret;
 import io.jenkins.plugins.ksm.KsmApplication;
 import io.jenkins.plugins.ksm.KsmSecret;
+import io.jenkins.plugins.ksm.MockConfig;
 import io.jenkins.plugins.ksm.credential.KsmCredential;
 import io.jenkins.plugins.ksm.notation.KsmNotation;
 import io.jenkins.plugins.ksm.notation.KsmTestNotation;
@@ -98,17 +99,17 @@ public class KsmBuildWrapperTest {
         ArrayList<String> uids = new ArrayList<>();
         uids.add("A_7YpGBUgRTeDEQLhVRo0Q");
 
+        HashMap <String, String> mockConfig = new MockConfig().makeConfig();
+
         KsmCredential credential = new KsmCredential(
                 CredentialsScope.GLOBAL,
                 "MYID",
                 "MYCRED",
                 "",
-                Secret.fromString("HvZKz9VBARON9nfhgbpTw3sG5EA7AVOkMXdHFu+cxXd1sHbUCoWM113tp1GdZ9iuhX+9YYl2wyqir8j637uBCA=="),
-                Secret.fromString("MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgeBjadIx4hRcZMkADIvhb076KWfsp4cmhnufDovLV"
-                        + "bxmgCgYIKoZIzj0DAQehRANCAAQKFzyJLkhasgDWC1Z5wnhFZ5416BqRL8TRMpJj2nOvfPs/wfsf8MXW2HUp54qz"
-                        + "zgi/zwLkNiFBmIzTGWE/A9oE"),
-                Secret.fromString("zhLwBKEIdiXaqVwlpnIXEl6jm/nO7WpPxYhKZv2LPGY="),
-                "keepersecurity.com",
+                Secret.fromString(mockConfig.get("clientId")),
+                Secret.fromString(mockConfig.get("privateKey")),
+                Secret.fromString(mockConfig.get("appKey")),
+                mockConfig.get("hostname"),
                 false,
                 true);
 

--- a/src/test/java/io/jenkins/plugins/ksm/credemtial/KsmCredentialTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/credemtial/KsmCredentialTest.java
@@ -3,10 +3,13 @@ package io.jenkins.plugins.ksm.credemtial;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
+import io.jenkins.plugins.ksm.MockConfig;
 import io.jenkins.plugins.ksm.credential.KsmCredential;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.HashMap;
 
 import static org.junit.Assert.*;
 
@@ -17,33 +20,29 @@ public class KsmCredentialTest {
     public static JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void testSmoke() {
+    public void testSmoke() throws Exception {
 
-        String clientId = "HvZKz9VBARON9nfhgbpTw3sG5EA7AVOkMXdHFu+cxXd1sHbUCoWM113tp1GdZ9iuhX+9YYl2wyqir8j637uBCA==";
-        String privateKey = "MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgeBjadIx4hRcZMkADIvhb076KWfsp4cmhnufDovLV"
-                + "bxmgCgYIKoZIzj0DAQehRANCAAQKFzyJLkhasgDWC1Z5wnhFZ5416BqRL8TRMpJj2nOvfPs/wfsf8MXW2HUp54qz"
-                + "zgi/zwLkNiFBmIzTGWE/A9oE";
-        String appKey = "zhLwBKEIdiXaqVwlpnIXEl6jm/nO7WpPxYhKZv2LPGY=";
+        HashMap<String, String> mockConfig = new MockConfig().makeConfig();
 
         KsmCredential credential = new KsmCredential(
                 CredentialsScope.GLOBAL,
                 "MYID",
                 "MYCRED",
                 "",
-                Secret.fromString(clientId),
-                Secret.fromString(privateKey),
-                Secret.fromString(appKey),
-                "keepersecurity.com",
+                Secret.fromString(mockConfig.get("clientId")),
+                Secret.fromString(mockConfig.get("privateKey")),
+                Secret.fromString(mockConfig.get("appKey")),
+                mockConfig.get("hostname"),
                 false,
                 true);
 
 
         assertEquals("MYID", credential.getId());
         assertEquals("MYCRED", credential.getDescription());
-        assertEquals(credential.getClientId().getPlainText(), clientId);
-        assertEquals(credential.getPrivateKey().getPlainText(), privateKey);
-        assertEquals(credential.getAppKey().getPlainText(), appKey);
-        assertEquals(credential.getHostname(), "keepersecurity.com");
+        assertEquals(credential.getClientId().getPlainText(), mockConfig.get("clientId"));
+        assertEquals(credential.getPrivateKey().getPlainText(), mockConfig.get("privateKey"));
+        assertEquals(credential.getAppKey().getPlainText(), mockConfig.get("appKey"));
+        assertEquals(credential.getHostname(), mockConfig.get("hostname"));
         assertFalse(credential.getSkipSslVerification());
         assertTrue(credential.getAllowConfigInject());
 
@@ -51,24 +50,20 @@ public class KsmCredentialTest {
     }
 
     @Test
-    public void testValidation() {
+    public void testValidation() throws Exception {
 
+        HashMap<String, String> mockConfig = new MockConfig().makeConfig();
 
-        String clientId = "HvZKz9VBARON9nfhgbpTw3sG5EA7AVOkMXdHFu+cxXd1sHbUCoWM113tp1GdZ9iuhX+9YYl2wyqir8j637uBCA==";
-        String privateKey = "MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgeBjadIx4hRcZMkADIvhb076KWfsp4cmhnufDovLV"
-                + "bxmgCgYIKoZIzj0DAQehRANCAAQKFzyJLkhasgDWC1Z5wnhFZ5416BqRL8TRMpJj2nOvfPs/wfsf8MXW2HUp54qz"
-                + "zgi/zwLkNiFBmIzTGWE/A9oE";
-        String appKey = "zhLwBKEIdiXaqVwlpnIXEl6jm/nO7WpPxYhKZv2LPGY=";
 
         KsmCredential credential = new KsmCredential(
                 CredentialsScope.GLOBAL,
                 "MYID",
                 "MYCRED",
                 "",
-                Secret.fromString(clientId),
-                Secret.fromString(privateKey),
-                Secret.fromString(appKey),
-                "keepersecurity.com",
+                Secret.fromString(mockConfig.get("clientId")),
+                Secret.fromString(mockConfig.get("privateKey")),
+                Secret.fromString(mockConfig.get("appKey")),
+                mockConfig.get("hostname"),
                 false,
                 true);
 

--- a/src/test/java/io/jenkins/plugins/ksm/workflow/KsmStepTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/workflow/KsmStepTest.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import hudson.FilePath;
 import hudson.util.Secret;
 import io.jenkins.plugins.ksm.KsmSecret;
+import io.jenkins.plugins.ksm.MockConfig;
 import io.jenkins.plugins.ksm.credential.KsmCredential;
 import io.jenkins.plugins.ksm.notation.KsmTestNotation;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -17,6 +18,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
 import org.junit.*;
+
 
 import static org.junit.Assert.assertFalse;
 
@@ -126,17 +128,17 @@ public class KsmStepTest {
         ArrayList<String> uids = new ArrayList<>();
         uids.add("A_7YpGBUgRTeDEQLhVRo0Q");
 
+        HashMap <String, String> mockConfig = new MockConfig().makeConfig();
+
         KsmCredential credential = new KsmCredential(
                 CredentialsScope.GLOBAL,
                 "MYID",
                 "",
                 "",
-                Secret.fromString("HvZKz9VBARON9nfhgbpTw3sG5EA7AVOkMXdHFu+cxXd1sHbUCoWM113tp1GdZ9iuhX+9YYl2wyqir8j637uBCA=="),
-                Secret.fromString("MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgeBjadIx4hRcZMkADIvhb076KWfsp4cmhnufDovLV"
-                        + "bxmgCgYIKoZIzj0DAQehRANCAAQKFzyJLkhasgDWC1Z5wnhFZ5416BqRL8TRMpJj2nOvfPs/wfsf8MXW2HUp54qz"
-                        + "zgi/zwLkNiFBmIzTGWE/A9oE"),
-                Secret.fromString("zhLwBKEIdiXaqVwlpnIXEl6jm/nO7WpPxYhKZv2LPGY="),
-                "keepersecurity.com",
+                Secret.fromString(mockConfig.get("clientId")),
+                Secret.fromString(mockConfig.get("privateKey")),
+                Secret.fromString(mockConfig.get("appKey")),
+                mockConfig.get("hostname"),
                 false,
                 true);
 


### PR DESCRIPTION
While the values are fake, they are getting reported. Remove the values from the tests.
Instead use a mock config generator to randomly generate fake config data.

Since the values are not hardcoded in the test code, the scans
should not trigger on the values.