### PR TITLE
Update the Keeper Secrets Manager SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.keepersecurity.secrets-manager</groupId>
       <artifactId>core</artifactId>
-      <version>16.2.1</version>
+      <version>16.2.8</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
@@ -58,20 +58,21 @@
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
     </dependency>
+
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.5.31</version>
+      <version>1.6.10</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.5.31</version>
+      <version>1.6.10</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
-      <version>1.5.31</version>
+      <version>1.6.10</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/jenkins/plugins/ksm/KsmQuery.java
+++ b/src/main/java/io/jenkins/plugins/ksm/KsmQuery.java
@@ -64,6 +64,9 @@ public class KsmQuery {
             logger.log(Level.WARNING, "Redeeming token resulted in error: " + e.getMessage());
             throw new Exception("Cannot redeem token: " + handleException(e));
         }
+
+        logger.log(Level.FINE, "Token redeemed");
+
         return storage;
     }
 

--- a/src/main/java/io/jenkins/plugins/ksm/notation/KsmTestNotation.java
+++ b/src/main/java/io/jenkins/plugins/ksm/notation/KsmTestNotation.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.ksm.notation;
 
 import com.keepersecurity.secretsManager.core.*;
+
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -135,10 +136,11 @@ public class KsmTestNotation extends KsmNotation {
             records.add(record);
         }
 
-        this.secrets = new KeeperSecrets(records);
+        AppData appData = new AppData("","");
+        this.secrets = new KeeperSecrets(appData, records, null, null);
     }
 
-    public KeeperSecrets getSecrets(SecretsManagerOptions options, List<String> uids) {
+    public KeeperSecrets getNotationSecrets(SecretsManagerOptions options, List<String> uids) {
         return this.secrets;
     }
 

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -6,6 +6,7 @@ com.keepersecurity.secretsManager.core.Password
 com.keepersecurity.secretsManager.core.Url
 com.keepersecurity.secretsManager.core.KeeperFile
 com.keepersecurity.secretsManager.core.KeeperFileData
+com.keepersecurity.secretsManager.core.AppData
 java.io.PrintStream
 java.io.ByteArrayOutputStream
 java.io.BufferedWriter


### PR DESCRIPTION
The KSM server is returning appData in the JSON response. The JSON
parser doesn't like the extra key in the JSON and throws an
exception. Update the SDK to accept the new key in JSON.

Updated Kotlin deps for new SDK.

Added more debug around calls to KSM server to see the timing of
the calls. There appears to be an issue where calls to the KSM
server are taking a long time to complete. This at reason show
when the call was started and finished.

Changed the plgins getSecrets to getNotationSecrets to be less
ambiguous with the SDK's getSecrets.