### PR TITLE
Fix skipping SSL

### DIFF
--- a/src/main/java/io/jenkins/plugins/ksm/credential/KsmCredential.java
+++ b/src/main/java/io/jenkins/plugins/ksm/credential/KsmCredential.java
@@ -46,7 +46,7 @@ public class KsmCredential extends BaseStandardCredentials {
         // If the token is not blank, or already an error, redeem the token.
         if (!token.trim().equals("") && (!token.trim().startsWith(KsmCredential.tokenErrorPrefix))){
             try {
-                LocalConfigStorage storage = KsmQuery.redeemToken(token, hostname);
+                LocalConfigStorage storage = KsmQuery.redeemToken(token, hostname, skipSslVerification);
                 clientId = Secret.fromString(storage.getString("clientId"));
                 appKey = Secret.fromString(storage.getString("appKey"));
                 privateKey = Secret.fromString(storage.getString("privateKey"));

--- a/src/main/resources/io/jenkins/plugins/ksm/credential/KsmCredential/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/ksm/credential/KsmCredential/config.jelly
@@ -26,7 +26,7 @@
             </f:entry>
             <f:validateButton
                     title="${%ValidateCredential}" progress="${%ValidateCredentialProgress}"
-                    method="testCredential" with="hostname,clientId,privateKey,appKey,useSkipSslVerification"/>
+                    method="testCredential" with="hostname,clientId,privateKey,appKey,skipSslVerification"/>
             <f:entry title="${%AllowConfigInject}" field="allowConfigInject">
                 <f:checkbox/>
             </f:entry>


### PR DESCRIPTION
There were two problems. The first was initializing a token would not
skip SSL certification. It was not coded to use the skip SSL flag.
The second was testing a credential always resulted in using SSL
certification even if the box was checked. Was using the wrong, non-existing,
field in the validation call.

Also add the SSL flag to log messages. And removed some debug messages
that were not needed.

