### PR TITLE
Throw error if we don't enough records back

### DIFF
--- a/src/main/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapper.java
+++ b/src/main/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapper.java
@@ -99,10 +99,17 @@ public class KsmBuildWrapper extends BuildWrapper {
                 if (notationItem.getError() == null) {
                     Object value = notationItem.getValue();
 
+                    // If the value is null, set the value to blank.
+                    if ( value == null ) {
+                        notationItem.setValue("");
+                        continue;
+                    }
+
                     // Make sure we are not trying to put binary data into an environmental variable.
                     if (notationItem.isDestinationEnvVar()) {
                         if (!(value instanceof String)) {
-                            notationItem.setError("Attempted to store binary data in an environmental variable.");
+                            notationItem.setError("Attempted to store binary data in an environmental variable. " +
+                                    "The type is " + value.getClass());
                         }
                     }
 

--- a/src/main/java/io/jenkins/plugins/ksm/notation/KsmNotation.java
+++ b/src/main/java/io/jenkins/plugins/ksm/notation/KsmNotation.java
@@ -205,7 +205,7 @@ public class KsmNotation {
         return downloadFile(file);
     }
 
-    public void run(KsmCredential credential, Map<String, KsmNotationItem> items) {
+    public void run(KsmCredential credential, Map<String, KsmNotationItem> items) throws Exception {
 
         SecretsManagerOptions options = KsmQuery.getOptions(
                 Secret.toString(credential.getClientId()),
@@ -238,6 +238,10 @@ public class KsmNotation {
                     "Did not receive the same number of record(s) as requested. " +
                             "Some of the record uid(s) may not exist in application."
             );
+            throw new Exception("Requested " + uniqueUids.size() + " record(s), received " +
+                    secrets.getRecords().size() + " records(s). This happens when a record does not exists in the " +
+                    "application, the record uid is wrong, or the record type is General. Make sure all the record " +
+                    "uids exist in your application and the records are not General type.");
         }
 
         for (Map.Entry<String, KsmNotationItem> entry : items.entrySet()) {


### PR DESCRIPTION
If a value is null, make it a blank value. The problem was due
to an application not have the record.

Instead of logging the problem, throw an error. This will save people
a lot of time from trying to figure out why valyes are blank.
