### PR TITLE
Update KSM SDK to 16.3.6 for entropy test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.keepersecurity.secrets-manager</groupId>
       <artifactId>core</artifactId>
-      <version>16.2.8</version>
+      <version>16.3.6</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
@@ -62,17 +62,17 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.6.10</version>
+      <version>1.6.21</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.6.10</version>
+      <version>1.6.21</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
-      <version>1.6.10</version>
+      <version>1.6.21</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/jenkins/plugins/ksm/KsmQuery.java
+++ b/src/main/java/io/jenkins/plugins/ksm/KsmQuery.java
@@ -32,30 +32,12 @@ public class KsmQuery {
     public static LocalConfigStorage redeemToken(String token, String hostname,
                                                  boolean allowUnverifiedCertificate) throws Exception {
 
-        // New style has the hostname prepended to the token, joined with a ":"
-        // TODO: Let the SDK handle this, however it's not working now.
-        if ( token.contains(":")) {
-            String[] parts = token.split(":");
-            if (parts.length != 2) {
-                throw new Exception("The region code/token appears to be formatted incorrectly.");
-            }
-
-            hostname = parts[0];
-            if((hostname == null) || (hostname.equals(""))) {
-                throw new Exception("The region code/hostname of the token is blank.");
-            }
-            token = parts[1];
-            if((token == null) || (token.equals(""))) {
-                throw new Exception("The hash code of the token is blank.");
-            }
-        }
-
         logger.log(Level.FINE, "Redeem token " + token +" from host " + hostname + "; Skip SSL = " +
                 allowUnverifiedCertificate);
 
         LocalConfigStorage storage = new LocalConfigStorage();
         try {
-            SecretsManager.initializeStorage(storage, token, getHostname(hostname));
+            SecretsManager.initializeStorage(storage, token, hostname);
             SecretsManagerOptions options = new SecretsManagerOptions(storage, null,
                     allowUnverifiedCertificate);
             KeeperSecrets secrets = SecretsManager.getSecrets(options);
@@ -95,7 +77,7 @@ public class KsmQuery {
         logger.log(Level.FINE, "Testing credentials; SSL Skip = " + allowUnverifiedCertificate);
 
         try {
-            SecretsManagerOptions options = getOptions(clientId, privateKey, appKey, getHostname(hostname),
+            SecretsManagerOptions options = getOptions(clientId, privateKey, appKey, hostname,
                     allowUnverifiedCertificate);
             KeeperSecrets secrets = SecretsManager.getSecrets(options);
             List<KeeperRecord> records = secrets.getRecords();
@@ -106,27 +88,5 @@ public class KsmQuery {
         }
 
         return null;
-    }
-
-    private static String getHostname(String hostname) {
-        // Allow for aliases.
-        switch (hostname) {
-            case "US":
-                hostname = "keepersecurity.com";
-                break;
-            case "EU":
-                hostname = "keepersecurity.eu";
-                break;
-            case "AU":
-                hostname = "keepersecurity.com.au";
-                break;
-            case "US_GOV":
-                hostname = "govcloud.keepersecurity.us";
-                break;
-            default:
-                // nothing
-        }
-
-        return hostname;
     }
 }


### PR DESCRIPTION
KSM-298

On some system, mostly Linux, if the system does not have a lot of activity there is a chance of low entropy. Entropy is used by SecrueRandom and it will block until enough exists.

KSM SDK 16.3.6 has a check and will throw an exception if not enough entropy exists.

    Slow SecureRandom detected!  Install one of the following entropy
    sources to improve speed of random number generator
    on your platform: 'haveged' or 'rng-tools'

Also removed the plugins handling of host aliases (ie US, EU, AU,..) and now uses the KSM SDK's handling.
