### PR TITLE
Fix #28 NPE in KsmCredential constructor when credentials are built by JCasC plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/ksm/credential/KsmCredential.java
+++ b/src/main/java/io/jenkins/plugins/ksm/credential/KsmCredential.java
@@ -2,8 +2,10 @@ package io.jenkins.plugins.ksm.credential;
 
 import com.cloudbees.plugins.credentials.*;
 import com.keepersecurity.secretsManager.core.LocalConfigStorage;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Item;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
@@ -37,14 +39,16 @@ public class KsmCredential extends BaseStandardCredentials {
 
     @DataBoundConstructor
     public KsmCredential(CredentialsScope scope, String id, String description,
-                         String token,
+                         @CheckForNull String token,
                          Secret clientId, Secret privateKey, Secret appKey,
                          String hostname,
                          boolean skipSslVerification, boolean allowConfigInject) {
         super(scope, id, description);
 
+        token = Util.fixNull(token).trim();
+
         // If the token is not blank, or already an error, redeem the token.
-        if (!token.trim().equals("") && (!token.trim().startsWith(KsmCredential.tokenErrorPrefix))){
+        if (!"".equals(token) && (!token.startsWith(KsmCredential.tokenErrorPrefix))){
             try {
                 LocalConfigStorage storage = KsmQuery.redeemToken(token, hostname, skipSslVerification);
                 clientId = Secret.fromString(storage.getString("clientId"));
@@ -70,7 +74,7 @@ public class KsmCredential extends BaseStandardCredentials {
             token = "";
         }
 
-        this.token = token.trim();
+        this.token = token;
         this.clientId = clientId;
         this.privateKey = privateKey;
         this.appKey = appKey;

--- a/src/test/java/io/jenkins/plugins/ksm/casc/CasCCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/casc/CasCCredentialsTest.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.ksm.casc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+
+import hudson.security.ACL;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.ksm.credential.KsmCredential;
+
+/**
+ * Test Jenkins configuration as code.
+ *
+ * @author Nikolas Falco
+ */
+public class CasCCredentialsTest {
+
+    @ClassRule
+    @ConfiguredWithCode("config-credentials.yaml")
+    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    public void import_system_credentials() {
+        List<KsmCredential> creds = CredentialsProvider.lookupCredentials(KsmCredential.class, j.jenkins, ACL.SYSTEM, Collections.emptyList());
+        assertThat(creds, hasSize(1));
+
+        final KsmCredential c = creds.get(0);
+        assertThat(c.getToken(), equalTo(""));
+        assertThat(c.getDescription(), equalTo("test"));
+        assertFalse(c.getSkipSslVerification());
+        assertTrue(c.getAllowConfigInject());
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/ksm/casc/config-credentials.yaml
+++ b/src/test/resources/io/jenkins/plugins/ksm/casc/config-credentials.yaml
@@ -1,0 +1,12 @@
+credentials:
+   system:
+      domainCredentials:
+      -  credentials:
+         - ksmCredential:
+                 allowConfigInject: true
+                 appKey: "{AQAAABAAAAAQGvDi8J6JJSbg7iwLBAPZRXTpdcxs8tBx6A4Cx4GyhZs=}"
+                 clientId: "{AQAAABAAAAAQV8woQ23ya+dVvLUgYccFGh75pXSQS+TBlXUWIF7qg40=}"
+                 description: "test"
+                 id: "123"
+                 privateKey: "{AQAAABAAAAAQZZbdRII6ICBlwua6U5CFiNYe3wMll3+hSTCm1+JUkiI=}"
+                 skipSslVerification: false


### PR DESCRIPTION
Fix the KsmCredential constructor with a guard on token variable that could be null when built from JCasC plugin because in the yaml token attribute is not serialized when empty or null.

I've add a test case to prove that the fix works as expected and will not fails at jenkins startup