### PR TITLE
Plugin maintenance pass: parent POM, baseline, KSM SDK 17, bug fixes

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,20 @@
+name: Jenkins Security Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: 'maven'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'windows', jdk: 21],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,7 @@
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 11],
     [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20231013</version>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>[1.1.1,)</version>
+      <version>20250517</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.keepersecurity.secrets-manager</groupId>
       <artifactId>core</artifactId>
-      <version>16.6.3</version>
+      <version>17.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.31</version>
+    <version>6.2153.vcf31911d10c4</version>
     <relativePath/>
   </parent>
 
@@ -16,8 +16,8 @@
   <properties>
     <revision>1.0</revision>
     <changelist></changelist>
-    <jenkins.baseline>2.504</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.addOpens />
     <jenkins.insaneHook />
@@ -32,7 +32,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5750.vec44cb_c78352</version>
+        <version>6398.v1d26a_dd495e2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.76</version>
+    <version>5.31</version>
     <relativePath/>
   </parent>
 
@@ -16,7 +16,8 @@
   <properties>
     <revision>1.0</revision>
     <changelist></changelist>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.addOpens />
     <jenkins.insaneHook />
@@ -30,8 +31,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
-        <version>2675.v1515e14da_7a_6</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>5750.vec44cb_c78352</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -116,7 +117,7 @@
     </license>
   </licenses>
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>

--- a/src/main/java/io/jenkins/plugins/ksm/KsmCommon.java
+++ b/src/main/java/io/jenkins/plugins/ksm/KsmCommon.java
@@ -122,22 +122,25 @@ public class KsmCommon {
         if (fileStr.startsWith("/") || fileStr.startsWith("\\")) {
             return false;
         }
-        Pattern pattern = Pattern.compile("^.:\\\\|/", Pattern.CASE_INSENSITIVE);
+        // Reject Windows drive-rooted paths (e.g. C:\foo, c:/foo). The previous
+        // pattern was "^.:\\\\|/" which, due to | precedence, also rejected any
+        // path containing '/' and so blocked legitimate subdirectory paths.
+        Pattern pattern = Pattern.compile("^.:[\\\\/]", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(fileStr);
-        boolean matchFound = matcher.find();
-        if (matchFound) {
+        if (matcher.find()) {
             return false;
         }
 
+        // Reject parent-directory traversal. Inspect every component including
+        // the leftmost; a do/while bound on getParentFile() != null skips the
+        // top component and lets paths like "../escape" through.
         File file = new File(fileStr);
-        do {
-            // Not sure if possible in Jenkins FilePath, however don't allow walk back up directory tree. No
-            // reason to ever use .. a file path.
-            if(file.getName().equals("..")) {
+        while (file != null) {
+            if (file.getName().equals("..")) {
                 return false;
             }
             file = file.getParentFile();
-        } while ((file != null) && (file.getParentFile() != null));
+        }
 
         return true;
     }

--- a/src/main/java/io/jenkins/plugins/ksm/KsmCommon.java
+++ b/src/main/java/io/jenkins/plugins/ksm/KsmCommon.java
@@ -12,7 +12,7 @@ import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.ksm.credential.KsmCredential;
 import jenkins.model.Jenkins;
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -69,7 +69,6 @@ public class KsmCommon {
                 .includeCurrentValue(credentialsId);
     }
 
-    @SuppressWarnings("unchecked")
     public static void addCredentialToEnv(KsmCredential credential, EnvVars newEnvVars, EnvVars existingEnvVars) {
 
         if (credential.getAllowConfigInject()) {
@@ -91,7 +90,7 @@ public class KsmCommon {
             obj.put("privateKey", Secret.toString(credential.getPrivateKey()));
             obj.put("appKey", Secret.toString(credential.getAppKey()));
             obj.put("hostname", credential.getHostname());
-            String json = obj.toJSONString();
+            String json = obj.toString();
             String configBase64 = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
 
             // Get the credential's description. If blank, make one based on the config #.

--- a/src/main/java/io/jenkins/plugins/ksm/KsmQuery.java
+++ b/src/main/java/io/jenkins/plugins/ksm/KsmQuery.java
@@ -4,9 +4,8 @@ import com.keepersecurity.secretsManager.core.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.*;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 
 public class KsmQuery {
@@ -19,11 +18,10 @@ public class KsmQuery {
 
         // See if this is one of our error message
         try {
-            JSONParser jsonParser = new JSONParser();
-            JSONObject obj = (JSONObject) jsonParser.parse(msg);
-            msg = (String) obj.get("message");
-        } catch (ParseException ignore) {
-            // Don't do anything. Keep msg the same.
+            JSONObject obj = new JSONObject(msg);
+            msg = obj.getString("message");
+        } catch (JSONException ignore) {
+            // Not a JSON error payload; keep msg as-is.
         }
 
         return msg;

--- a/src/main/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapper.java
+++ b/src/main/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapper.java
@@ -45,8 +45,12 @@ public class KsmBuildWrapper extends BuildWrapper {
 
     protected void getSecrets(Job job) {
 
+        // Reset all per-run state. The BuildWrapper instance is reused across builds,
+        // so a stale error from a prior run (e.g., a 502 from the KSM endpoint) must
+        // not leak forward and abort future builds (#52).
         notationItems = new HashMap<>();
         secretValues = new ArrayList<>();
+        systemSecretError = null;
 
         // Since we are initializing this from the console, any exceptions just kill the console. Handle the errors
         // in the setup.

--- a/src/main/java/io/jenkins/plugins/ksm/notation/KsmNotation.java
+++ b/src/main/java/io/jenkins/plugins/ksm/notation/KsmNotation.java
@@ -18,6 +18,15 @@ public class KsmNotation {
     // A notation might start with a prefix, that will need to be removed. This is the that String prefix.
     public static final String notationPrefix = "keeper";
 
+    // Keeper record UIDs are 22-character URL-safe base64 strings. The SDK
+    // additionally accepts a record title in place of a UID; when the token
+    // does not match this pattern we treat it as a title (#43).
+    private static final Pattern UID_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{22}$");
+
+    public static boolean looksLikeUid(String token) {
+        return token != null && UID_PATTERN.matcher(token).matches();
+    }
+
     private static final Logger logger = Logger.getLogger(KsmNotation.class.getName());
 
     /**
@@ -109,8 +118,8 @@ public class KsmNotation {
             throw new Exception(msg);
         }
         String uid = notationParts[0];
-        if (uid.length() != 22) {
-            throw new Exception("The record uid is not the correct length.");
+        if (uid.isEmpty()) {
+            throw new Exception("The record uid or title is missing.");
         }
 
         KsmFieldDataEnumType fieldDataType = KsmFieldDataEnumType.getEnumByString(notationParts[1]);
@@ -201,6 +210,10 @@ public class KsmNotation {
         return SecretsManager.getSecrets(options, uids);
     }
 
+    public KeeperSecrets getNotationSecrets(SecretsManagerOptions options) {
+        return SecretsManager.getSecrets(options);
+    }
+
     public byte[] downloadDataFile(KeeperFile file) {
         return downloadFile(file);
     }
@@ -214,34 +227,46 @@ public class KsmNotation {
                 credential.getHostname(),
                 credential.getSkipSslVerification());
 
-        // Find all the unique record UIDs in the requests.
-        Set<String> uniqueUids = new HashSet<>();
+        // Collect the unique record tokens (UIDs or titles) from the requests.
+        Set<String> uniqueTokens = new HashSet<>();
+        boolean allUids = true;
         for (Map.Entry<String, KsmNotationItem> entry : items.entrySet()) {
             KsmNotationItem item = entry.getValue();
             // Skip over any item already flagged as an error.
             if(item.getError() != null) {
                 continue;
             }
-            uniqueUids.add(item.getUid());
+            String token = item.getUid();
+            uniqueTokens.add(token);
+            if (!looksLikeUid(token)) {
+                allUids = false;
+            }
         }
 
-        // Query the unique record ids.
-        logger.log(Level.FINE, "Retrieving " + uniqueUids.size() + " record(s).");
-        KeeperSecrets secrets = this.getNotationSecrets(options, new ArrayList<>(uniqueUids));
-        logger.log(Level.FINE, "Got " + secrets.getRecords().size() + " record(s).");
+        // If every token looks like a UID, use the server-side filter for
+        // efficiency and verify the record count. If any token is a title,
+        // fetch all records and let the SDK resolve titles (#43).
+        KeeperSecrets secrets;
+        if (allUids) {
+            logger.log(Level.FINE, "Retrieving " + uniqueTokens.size() + " record(s) by UID.");
+            secrets = this.getNotationSecrets(options, new ArrayList<>(uniqueTokens));
+            logger.log(Level.FINE, "Got " + secrets.getRecords().size() + " record(s).");
 
-        // The request uid and response record number should match. If not, one of the UID doesn't exist or
-        // application doesn't have access.
-        if ( uniqueUids.size() != secrets.getRecords().size() ) {
-            logger.log(
-                    Level.WARNING,
-                    "Did not receive the same number of record(s) as requested. " +
-                            "Some of the record uid(s) may not exist in application."
-            );
-            throw new Exception("Requested " + uniqueUids.size() + " record(s), received " +
-                    secrets.getRecords().size() + " records(s). This happens when a record does not exists in the " +
-                    "application, the record uid is wrong, or the record type is General. Make sure all the record " +
-                    "uids exist in your application and the records are not General type.");
+            if (uniqueTokens.size() != secrets.getRecords().size()) {
+                logger.log(
+                        Level.WARNING,
+                        "Did not receive the same number of record(s) as requested. " +
+                                "Some of the record uid(s) may not exist in application."
+                );
+                throw new Exception("Requested " + uniqueTokens.size() + " record(s), received " +
+                        secrets.getRecords().size() + " records(s). This happens when a record does not exists in the " +
+                        "application, the record uid is wrong, or the record type is General. Make sure all the record " +
+                        "uids exist in your application and the records are not General type.");
+            }
+        } else {
+            logger.log(Level.FINE, "Notation includes record title(s); retrieving all records.");
+            secrets = this.getNotationSecrets(options);
+            logger.log(Level.FINE, "Got " + secrets.getRecords().size() + " record(s).");
         }
 
         for (Map.Entry<String, KsmNotationItem> entry : items.entrySet()) {

--- a/src/main/java/io/jenkins/plugins/ksm/notation/KsmTestNotation.java
+++ b/src/main/java/io/jenkins/plugins/ksm/notation/KsmTestNotation.java
@@ -132,7 +132,8 @@ public class KsmTestNotation extends KsmNotation {
                     "INFOLDERUID",
                     data,
                     0L,
-                    files
+                    files,
+                    null
             );
             records.add(record);
         }

--- a/src/main/java/io/jenkins/plugins/ksm/notation/KsmTestNotation.java
+++ b/src/main/java/io/jenkins/plugins/ksm/notation/KsmTestNotation.java
@@ -146,6 +146,11 @@ public class KsmTestNotation extends KsmNotation {
         return this.secrets;
     }
 
+    @Override
+    public KeeperSecrets getNotationSecrets(SecretsManagerOptions options) {
+        return this.secrets;
+    }
+
     public byte[] downloadDataFile(KeeperFile file) {
         String name = file.getData().getName();
         return fileCache.get(name);

--- a/src/main/resources/io/jenkins/plugins/ksm/credential/KsmCredential/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/ksm/credential/KsmCredential/config.jelly
@@ -32,9 +32,7 @@
             </f:entry>
             <f:entry title="${%Id}" field="${instance != null ? null : 'id'}">
                 <f:textbox name="_.id"
-                           value="${instance != null ? instance.id : null}"
-                           checkUrl="${instance != null ? null : descriptor.getCheckUrl('id')}"
-                />
+                           value="${instance != null ? instance.id : null}"/>
             </f:entry>
         </f:advanced>
     </f:section>

--- a/src/test/java/io/jenkins/plugins/ksm/KsmCommonTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/KsmCommonTest.java
@@ -1,0 +1,51 @@
+package io.jenkins.plugins.ksm;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class KsmCommonTest {
+
+    @Test
+    public void validFilePathRejectsAbsoluteUnixPath() {
+        assertFalse(KsmCommon.validFilePath("/etc/passwd"));
+        assertFalse(KsmCommon.validFilePath("/var/log/secret"));
+    }
+
+    @Test
+    public void validFilePathRejectsAbsoluteWindowsPath() {
+        assertFalse(KsmCommon.validFilePath("\\Windows\\System32\\secret"));
+        assertFalse(KsmCommon.validFilePath("C:\\Users\\admin\\secret"));
+        assertFalse(KsmCommon.validFilePath("c:/Users/admin/secret"));
+    }
+
+    @Test
+    public void validFilePathRejectsParentTraversal() {
+        assertFalse(KsmCommon.validFilePath("../escape"));
+        assertFalse(KsmCommon.validFilePath("foo/../escape"));
+        assertFalse(KsmCommon.validFilePath("a/b/../../escape"));
+    }
+
+    @Test
+    public void validFilePathRejectsBareDotDot() {
+        // A path of just "..": new File("..").getParentFile() is null, so the
+        // walker must still inspect the first component, otherwise "..": passes.
+        assertFalse(KsmCommon.validFilePath(".."));
+    }
+
+    @Test
+    public void validFilePathAcceptsPlainFileName() {
+        assertTrue(KsmCommon.validFilePath("secret.txt"));
+        assertTrue(KsmCommon.validFilePath("password"));
+        assertTrue(KsmCommon.validFilePath("my.png"));
+    }
+
+    @Test
+    public void validFilePathAcceptsSubdirectory() {
+        // writeFileToWorkspace() creates parent dirs via mkdirs(); valid file
+        // paths must allow nested directories like "secrets/db-password".
+        assertTrue(KsmCommon.validFilePath("secrets/db-password"));
+        assertTrue(KsmCommon.validFilePath("a/b/c/secret.txt"));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/ksm/KsmSecretTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/KsmSecretTest.java
@@ -1,0 +1,114 @@
+package io.jenkins.plugins.ksm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class KsmSecretTest {
+
+    private static final String NOTATION = "keeper://A_7YpGBUgRTeDEQLhVRo0Q/field/login";
+
+    @Test
+    public void validateAcceptsEnvVarDestination() throws Exception {
+        new KsmSecret(NOTATION, KsmSecret.destinationEnvVar, "MY_VAR", null).validate();
+    }
+
+    @Test
+    public void validateAcceptsFilePathDestination() throws Exception {
+        new KsmSecret(NOTATION, KsmSecret.destinationFilePath, null, "secret.txt").validate();
+    }
+
+    @Test
+    public void validateRejectsMissingDestination() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(NOTATION, null, "X", null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("destination"));
+    }
+
+    @Test
+    public void validateRejectsBlankDestination() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(NOTATION, "", "X", null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("destination"));
+    }
+
+    @Test
+    public void validateRejectsUnknownDestination() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(NOTATION, "elsewhere", "X", null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("destination"));
+    }
+
+    @Test
+    public void validateRejectsBlankEnvVarOnEnvDestination() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(NOTATION, KsmSecret.destinationEnvVar, "", null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("envvar"));
+    }
+
+    @Test
+    public void validateRejectsNullEnvVarOnEnvDestination() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(NOTATION, KsmSecret.destinationEnvVar, null, null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("envvar"));
+    }
+
+    @Test
+    public void validateRejectsBlankFilePathOnFileDestination() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(NOTATION, KsmSecret.destinationFilePath, null, "").validate());
+        assertTrue(e.getMessage().toLowerCase().contains("filepath"));
+    }
+
+    @Test
+    public void validateRejectsBlankNotation() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret("", KsmSecret.destinationEnvVar, "MY_VAR", null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("notation"));
+    }
+
+    @Test
+    public void validateRejectsNullNotation() {
+        Exception e = assertThrows(Exception.class,
+                () -> new KsmSecret(null, KsmSecret.destinationEnvVar, "MY_VAR", null).validate());
+        assertTrue(e.getMessage().toLowerCase().contains("notation"));
+    }
+
+    @Test
+    public void buildSecretNameUsesEnvVarForEnvDestination() {
+        assertEquals("LOGIN",
+                KsmSecret.buildSecretName(KsmSecret.destinationEnvVar, "LOGIN", null));
+    }
+
+    @Test
+    public void buildSecretNameUsesFilePathForFileDestination() {
+        assertEquals("secret.txt",
+                KsmSecret.buildSecretName(KsmSecret.destinationFilePath, null, "secret.txt"));
+    }
+
+    @Test
+    public void buildSecretNameFallsBackToFilePathWhenEnvVarNull() {
+        // For env destination, a null envVar falls through to filePath. Not a
+        // typical config, but the contract should be deterministic.
+        assertEquals("fallback.txt",
+                KsmSecret.buildSecretName(KsmSecret.destinationEnvVar, null, "fallback.txt"));
+    }
+
+    @Test
+    public void getNameDelegatesToBuildSecretName() {
+        KsmSecret env = new KsmSecret(NOTATION, KsmSecret.destinationEnvVar, "PASSWORD", null);
+        assertEquals("PASSWORD", env.getName());
+        KsmSecret file = new KsmSecret(NOTATION, KsmSecret.destinationFilePath, null, "out.txt");
+        assertEquals("out.txt", file.getName());
+    }
+
+    @Test
+    public void isDestinationTypeIsCaseInsensitive() {
+        KsmSecret s = new KsmSecret(NOTATION, KsmSecret.destinationEnvVar, "X", null);
+        assertEquals("true", s.isDestinationType("ENV"));
+        assertEquals("true", s.isDestinationType("env"));
+        assertEquals("", s.isDestinationType("file"));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapperTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapperTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -283,5 +284,45 @@ public class KsmBuildWrapperTest {
         pattern = Pattern.compile("http://localhost", Pattern.MULTILINE);
         matcher = pattern.matcher(consoleLog);
         assertFalse(matcher.find());
+    }
+
+    /**
+     * Regression test for #52: a stale error from a prior run (e.g., a 502 from
+     * the KSM endpoint) must not survive on the BuildWrapper instance and abort
+     * subsequent builds. getSecrets() must reset systemSecretError on every call.
+     */
+    @Test
+    public void testStaleErrorIsClearedAcrossRuns() throws Exception {
+
+        HashMap<String, String> mockConfig = new MockConfig().makeConfig();
+        KsmCredential credential = new KsmCredential(
+                CredentialsScope.GLOBAL, "STALEID", "STALECRED", "",
+                Secret.fromString(mockConfig.get("clientId")),
+                Secret.fromString(mockConfig.get("privateKey")),
+                Secret.fromString(mockConfig.get("appKey")),
+                mockConfig.get("hostname"),
+                false, true);
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
+                Collections.singletonMap(Domain.global(), Collections.singletonList(credential)));
+
+        KsmTestNotation notation = new KsmTestNotation();
+        JSONObject obj = new JSONObject();
+        obj.put("secrets", new JSONArray());
+        notation.addTestData(obj.toJSONString());
+
+        KsmApplication app = new KsmApplication(credential.getId(), new ArrayList<>());
+        TestWrapper wrapper = new TestWrapper(Collections.singletonList(app), notation);
+
+        Field errField = KsmBuildWrapper.class.getDeclaredField("systemSecretError");
+        errField.setAccessible(true);
+        errField.set(wrapper, "stale 502 from previous run");
+        assertNotNull(errField.get(wrapper));
+
+        Run<?, ?> build = mock(Build.class);
+        when(build.getParent()).thenReturn(null);
+        wrapper.run(new PrintStream(new ByteArrayOutputStream()), build.getParent());
+
+        assertNull("systemSecretError must be reset at the start of getSecrets",
+                errField.get(wrapper));
     }
 }

--- a/src/test/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapperTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/builder/KsmBuildWrapperTest.java
@@ -32,8 +32,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.json.simple.JSONObject;
-import org.json.simple.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONArray;
 
 class TestWrapper extends KsmBuildWrapper implements Serializable {
 
@@ -71,7 +71,6 @@ public class KsmBuildWrapperTest {
     @ClassRule
     public static JenkinsRule j = new JenkinsRule();
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testBuilder() throws Exception {
 
@@ -156,25 +155,25 @@ public class KsmBuildWrapperTest {
         field.put("label", "login");
         field.put("fieldType", "Login");
         JSONArray value = new JSONArray();
-        value.add("My$Login");
+        value.put("My$Login");
         field.put("values", value);
-        fields.add(field);
+        fields.put(field);
         // Field password
         field = new JSONObject();
         field.put("label", "password");
         field.put("fieldType", "Password");
         value = new JSONArray();
-        value.add("Pa$$w0rd!!");
+        value.put("Pa$$w0rd!!");
         field.put("values", value);
-        fields.add(field);
+        fields.put(field);
         // Field URL
         field = new JSONObject();
         field.put("label", "url");
         field.put("fieldType", "Url");
         value = new JSONArray();
-        value.add("http://localhost");
+        value.put("http://localhost");
         field.put("values", value);
-        fields.add(field);
+        fields.put(field);
 
         secret1.put("fields", fields);
 
@@ -183,14 +182,14 @@ public class KsmBuildWrapperTest {
         JSONObject file = new JSONObject();
         file.put("name", "my.png");
         file.put("data", pngBase64);
-        files.add(file);
+        files.put(file);
         secret1.put("files", files);
 
-        array.add(secret1);
+        array.put(secret1);
         obj.put("secrets", array);
         // DONE making test JSON
 
-        notation.addTestData(obj.toJSONString());
+        notation.addTestData(obj.toString());
 
         KsmApplication application = new KsmApplication(credentialId, secrets);
         List<KsmApplication> applications = new ArrayList<>();
@@ -308,7 +307,7 @@ public class KsmBuildWrapperTest {
         KsmTestNotation notation = new KsmTestNotation();
         JSONObject obj = new JSONObject();
         obj.put("secrets", new JSONArray());
-        notation.addTestData(obj.toJSONString());
+        notation.addTestData(obj.toString());
 
         KsmApplication app = new KsmApplication(credential.getId(), new ArrayList<>());
         TestWrapper wrapper = new TestWrapper(Collections.singletonList(app), notation);

--- a/src/test/java/io/jenkins/plugins/ksm/notation/KsmNotationTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/notation/KsmNotationTest.java
@@ -1,7 +1,15 @@
 package io.jenkins.plugins.ksm.notation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.*;
 
 public class KsmNotationTest {
+
+    private static final String GOOD_UID = "A_7YpGBUgRTeDEQLhVRo0Q";
 
     @Test
     public void testSmokeTest() {
@@ -65,5 +73,98 @@ public class KsmNotationTest {
         } catch(Exception e) {
             Assert.fail("Exception was thrown " + e.getMessage());
         }
+    }
+
+    @Test
+    public void parseAcceptsNotationWithoutPrefix() throws Exception {
+        KsmNotationItem result = KsmNotation.parse("ABC", GOOD_UID + "/field/login", false);
+        assertEquals(GOOD_UID, result.getUid());
+        assertEquals(KsmFieldDataEnumType.STANDARD, result.getFieldDataType());
+        assertEquals("login", result.getFieldKey());
+    }
+
+    @Test
+    public void parseAcceptsFileSelector() throws Exception {
+        KsmNotationItem result = KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/file/my.png", false);
+        assertEquals(KsmFieldDataEnumType.FILE, result.getFieldDataType());
+        assertEquals("my.png", result.getFieldKey());
+    }
+
+    @Test
+    public void parseRejectsMissingFieldType() {
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID, false));
+        assertTrue(e.getMessage().toLowerCase().contains("missing"));
+    }
+
+    @Test
+    public void parseRejectsTooFewParts() {
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/field", false));
+        assertTrue(e.getMessage().toLowerCase().contains("missing"));
+    }
+
+    @Test
+    public void parseRejectsTooManyParts() {
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/field/login/extra", false));
+        assertTrue(e.getMessage().toLowerCase().contains("too many"));
+    }
+
+    @Test
+    public void parseRejectsShortUid() {
+        // The plugin currently enforces a 22-char record token. SDK supports
+        // record-by-title lookup; broader support is tracked as a follow-up.
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://SHORT/field/login", false));
+        assertTrue(e.getMessage().toLowerCase().contains("uid"));
+    }
+
+    @Test
+    public void parseRejectsUnknownFieldType() {
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/bogus/login", false));
+        assertTrue(e.getMessage().toLowerCase().contains("invalid"));
+    }
+
+    @Test
+    public void parseRejectsThreeBrackets() {
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/custom_field/name[1][a][b]", false));
+        assertTrue(e.getMessage().toLowerCase().contains("max 2"));
+    }
+
+    @Test
+    public void parseRejectsEmptySecondPredicate() {
+        // Second [] must be a dictionary key, never numeric and never blank.
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/custom_field/name[0][]", false));
+        assertTrue(e.getMessage().toLowerCase().contains("blank")
+                || e.getMessage().toLowerCase().contains("dictionary"));
+    }
+
+    @Test
+    public void parseRejectsNumericSecondPredicate() {
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/custom_field/name[0][1]", false));
+        assertTrue(e.getMessage().toLowerCase().contains("dictionary"));
+    }
+
+    @Test
+    public void parseRejectsArrayWithDictKey() {
+        // First [] returns the entire array; cannot combine with a second key.
+        Exception e = assertThrows(Exception.class,
+                () -> KsmNotation.parse("ABC", "keeper://" + GOOD_UID + "/custom_field/name[][first]", false));
+        assertTrue(e.getMessage().toLowerCase().contains("index"));
+    }
+
+    @Test
+    public void parseTreatsUnparseableFirstPredicateAsNoKey() throws Exception {
+        // A predicate like [a-b] does not match the int parser nor the
+        // dictKey regex (no hyphens). Behavior is "no key, default index 0".
+        KsmNotationItem result = KsmNotation.parse("ABC",
+                "keeper://" + GOOD_UID + "/custom_field/name[a-b]", false);
+        assertEquals(Integer.valueOf(0), result.getArrayIndex());
+        assertNull(result.getDictKey());
     }
 }

--- a/src/test/java/io/jenkins/plugins/ksm/notation/KsmNotationTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/notation/KsmNotationTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.ksm.notation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -112,12 +113,142 @@ public class KsmNotationTest {
     }
 
     @Test
-    public void parseRejectsShortUid() {
-        // The plugin currently enforces a 22-char record token. SDK supports
-        // record-by-title lookup; broader support is tracked as a follow-up.
+    public void parseAcceptsRecordTitleAsToken() throws Exception {
+        // The SDK supports record lookup by title; the plugin no longer
+        // rejects non-22-char tokens (#43).
+        KsmNotationItem result = KsmNotation.parse("ABC",
+                "keeper://My Record Title/field/login", false);
+        assertEquals("My Record Title", result.getUid());
+        assertEquals(KsmFieldDataEnumType.STANDARD, result.getFieldDataType());
+        assertEquals("login", result.getFieldKey());
+    }
+
+    @Test
+    public void parseRejectsEmptyToken() {
         Exception e = assertThrows(Exception.class,
-                () -> KsmNotation.parse("ABC", "keeper://SHORT/field/login", false));
-        assertTrue(e.getMessage().toLowerCase().contains("uid"));
+                () -> KsmNotation.parse("ABC", "keeper:///field/login", false));
+        assertTrue(e.getMessage().toLowerCase().contains("missing"));
+    }
+
+    @Test
+    public void looksLikeUidAcceptsTwentyTwoCharBase64() {
+        assertTrue(KsmNotation.looksLikeUid("A_7YpGBUgRTeDEQLhVRo0Q"));
+        assertTrue(KsmNotation.looksLikeUid("abcdefghijklmnopqrstuv"));
+        assertTrue(KsmNotation.looksLikeUid("ABCDEFGHIJKLMNOPQRSTUV"));
+        assertTrue(KsmNotation.looksLikeUid("0123456789012345678901"));
+        assertTrue(KsmNotation.looksLikeUid("aaaa-aaaa_aaaa-aaaa_aa"));
+    }
+
+    @Test
+    public void looksLikeUidAcceptsLeadingDash() {
+        // Legacy records may have UIDs starting with '-'. Newer records do not,
+        // but we still see them in the wild and must not misclassify them as
+        // titles.
+        assertTrue(KsmNotation.looksLikeUid("-AbCdEfGhIjKlMnOpQrStU"));  // 22 chars
+        assertTrue(KsmNotation.looksLikeUid("-_---_---_---_---_---_"));  // 22 chars
+        assertTrue(KsmNotation.looksLikeUid("-1234567890ABCDEFGHIJK"));  // 22 chars
+    }
+
+    @Test
+    public void looksLikeUidRejectsOtherFormats() {
+        assertFalse(KsmNotation.looksLikeUid(null));
+        assertFalse(KsmNotation.looksLikeUid(""));
+        assertFalse(KsmNotation.looksLikeUid("short"));
+        assertFalse(KsmNotation.looksLikeUid("waytoolongwaytoolongwaytoolongwaytoolong"));
+        assertFalse(KsmNotation.looksLikeUid("contains spaces in name"));
+        assertFalse(KsmNotation.looksLikeUid("hasplus+signsinit_aaaa"));
+        assertFalse(KsmNotation.looksLikeUid("My Record Title"));
+    }
+
+    @Test
+    public void parseAcceptsLeadingDashUid() throws Exception {
+        // Legacy UIDs may start with '-'; ensure the parser does not treat them
+        // as something else and that looksLikeUid agrees.
+        String uid = "-AbCdEfGhIjKlMnOpQrStU";  // 22 chars
+        KsmNotationItem result = KsmNotation.parse("ABC", "keeper://" + uid + "/field/login", false);
+        assertEquals(uid, result.getUid());
+        assertTrue(KsmNotation.looksLikeUid(result.getUid()));
+    }
+
+    @Test
+    public void parseSetsCorrectEnumForEachSelector() throws Exception {
+        assertEquals(KsmFieldDataEnumType.STANDARD,
+                KsmNotation.parse("X", "keeper://" + GOOD_UID + "/field/login", false).getFieldDataType());
+        assertEquals(KsmFieldDataEnumType.CUSTOM,
+                KsmNotation.parse("X", "keeper://" + GOOD_UID + "/custom_field/MyLabel", false).getFieldDataType());
+        assertEquals(KsmFieldDataEnumType.FILE,
+                KsmNotation.parse("X", "keeper://" + GOOD_UID + "/file/qr.png", false).getFieldDataType());
+    }
+
+    @Test
+    public void parseExtractsArrayIndexFromFirstPredicate() throws Exception {
+        KsmNotationItem r = KsmNotation.parse("X", "keeper://" + GOOD_UID + "/custom_field/phone[2]", false);
+        assertEquals("phone", r.getFieldKey());
+        assertEquals(Integer.valueOf(2), r.getArrayIndex());
+        assertEquals(Boolean.TRUE, r.getReturnSingle());
+        assertNull(r.getDictKey());
+    }
+
+    @Test
+    public void parseExtractsDictKeyFromFirstPredicate() throws Exception {
+        // Mirrors SDK test: /custom_field/name[first] returns the dict key.
+        KsmNotationItem r = KsmNotation.parse("X", "keeper://" + GOOD_UID + "/custom_field/name[first]", false);
+        assertEquals("name", r.getFieldKey());
+        assertEquals(Integer.valueOf(0), r.getArrayIndex());
+        assertEquals("first", r.getDictKey());
+    }
+
+    @Test
+    public void parseExtractsBothPredicates() throws Exception {
+        // Mirrors SDK test: /custom_field/phone[0][number].
+        KsmNotationItem r = KsmNotation.parse("X", "keeper://" + GOOD_UID + "/custom_field/phone[0][number]", false);
+        assertEquals("phone", r.getFieldKey());
+        assertEquals(Integer.valueOf(0), r.getArrayIndex());
+        assertEquals("number", r.getDictKey());
+        assertEquals(Boolean.TRUE, r.getReturnSingle());
+    }
+
+    @Test
+    public void parseEmptyBracketsMeansFullArray() throws Exception {
+        KsmNotationItem r = KsmNotation.parse("X", "keeper://" + GOOD_UID + "/field/login[]", false);
+        assertEquals(Boolean.FALSE, r.getReturnSingle());
+        assertEquals(Integer.valueOf(0), r.getArrayIndex());
+        assertNull(r.getDictKey());
+    }
+
+    @Test
+    public void parseHandlesLabelsContainingSpaces() throws Exception {
+        // SDK supports custom field labels with spaces like "My Custom 2".
+        KsmNotationItem r = KsmNotation.parse("X",
+                "keeper://" + GOOD_UID + "/custom_field/My Custom 2[1]", false);
+        assertEquals("My Custom 2", r.getFieldKey());
+        assertEquals(Integer.valueOf(1), r.getArrayIndex());
+    }
+
+    @Test
+    public void parseHandlesFileNameWithDot() throws Exception {
+        KsmNotationItem r = KsmNotation.parse("X",
+                "keeper://" + GOOD_UID + "/file/qr.png", false);
+        assertEquals(KsmFieldDataEnumType.FILE, r.getFieldDataType());
+        assertEquals("qr.png", r.getFieldKey());
+    }
+
+    @Test
+    public void parseTitleTokenIsNotMisclassifiedAsUid() throws Exception {
+        KsmNotationItem r = KsmNotation.parse("X",
+                "keeper://My Record/field/login", false);
+        assertEquals("My Record", r.getUid());
+        assertFalse(KsmNotation.looksLikeUid(r.getUid()));
+    }
+
+    @Test
+    public void parseHonoursAllowFailureFlag() throws Exception {
+        KsmNotationItem r = KsmNotation.parse("X",
+                "keeper://" + GOOD_UID + "/field/login", true);
+        assertTrue(r.getAllowFailure());
+        KsmNotationItem r2 = KsmNotation.parse("X",
+                "keeper://" + GOOD_UID + "/field/login", false);
+        assertFalse(r2.getAllowFailure());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/ksm/workflow/KsmStepTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/workflow/KsmStepTest.java
@@ -12,8 +12,8 @@ import io.jenkins.plugins.ksm.notation.KsmTestNotation;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.jvnet.hudson.test.JenkinsRule;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
@@ -27,7 +27,6 @@ public class KsmStepTest {
     @ClassRule
     public static JenkinsRule j = new JenkinsRule();
 
-    @SuppressWarnings("unchecked")
     @Before
     public void makeTestData() throws UnsupportedEncodingException {
 
@@ -68,25 +67,25 @@ public class KsmStepTest {
         field.put("label", "login");
         field.put("fieldType", "Login");
         JSONArray value = new JSONArray();
-        value.add("My$Login");
+        value.put("My$Login");
         field.put("values", value);
-        fields.add(field);
+        fields.put(field);
         // Field password
         field = new JSONObject();
         field.put("label", "password");
         field.put("fieldType", "Password");
         value = new JSONArray();
-        value.add("Pa$$w0rd!!");
+        value.put("Pa$$w0rd!!");
         field.put("values", value);
-        fields.add(field);
+        fields.put(field);
         // Field URL
         field = new JSONObject();
         field.put("label", "url");
         field.put("fieldType", "Url");
         value = new JSONArray();
-        value.add("http://localhost");
+        value.put("http://localhost");
         field.put("values", value);
-        fields.add(field);
+        fields.put(field);
 
         secret1.put("fields", fields);
 
@@ -95,14 +94,14 @@ public class KsmStepTest {
         JSONObject file = new JSONObject();
         file.put("name", "my.png");
         file.put("data", pngBase64);
-        files.add(file);
+        files.put(file);
         secret1.put("files", files);
 
-        array.add(secret1);
+        array.put(secret1);
         obj.put("secrets", array);
         // DONE making test JSON
 
-        notation.writeJsonData(obj.toJSONString());
+        notation.writeJsonData(obj.toString());
     }
 
     @After

--- a/src/test/java/io/jenkins/plugins/ksm/workflow/KsmStepTest.java
+++ b/src/test/java/io/jenkins/plugins/ksm/workflow/KsmStepTest.java
@@ -174,4 +174,44 @@ public class KsmStepTest {
         // Make sure the png is missing
         assertFalse(workspace.child("my.png").exists());
     }
+
+    /**
+     * Issue #43: notation should accept a record title in place of a UID.
+     * The SDK already resolves both; the plugin's parser used to reject any
+     * token that was not exactly 22 characters.
+     */
+    @Test
+    public void testStepWithRecordTitle() throws Exception {
+
+        HashMap<String, String> mockConfig = new MockConfig().makeConfig();
+
+        KsmCredential credential = new KsmCredential(
+                CredentialsScope.GLOBAL, "TITLE_ID", "", "",
+                Secret.fromString(mockConfig.get("clientId")),
+                Secret.fromString(mockConfig.get("privateKey")),
+                Secret.fromString(mockConfig.get("appKey")),
+                mockConfig.get("hostname"),
+                false, true);
+
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
+                Collections.singletonMap(Domain.global(), Collections.singletonList(credential)));
+
+        WorkflowJob job = j.getInstance().createProject(WorkflowJob.class, "test-workflow-job-title");
+        // The mock record's title is "My Record" (see makeTestData()).
+        String pipelineScript
+                = "node {\n"
+                + "        withKsm(application: [\n"
+                + "          [ credentialsId: '" + credential.getId() + "',\n"
+                + "            secrets: [\n"
+                + "              [destination: 'env', envVar: 'MY_LOGIN', notation: 'keeper://My Record/field/login']\n"
+                + "            ]\n"
+                + "          ]\n"
+                + "        ]) {\n"
+                + "          echo MY_LOGIN\n"
+                + "        }\n"
+                + "}";
+        job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+        WorkflowRun completedBuild = j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        j.assertLogContains("****", completedBuild);
+    }
 }


### PR DESCRIPTION
Internal tracking: KSM-935.

Maintenance PR covering open issues, open PRs, and new features from the
KSM Java SDK 17 line.

## Changes

**Jenkins ecosystem hygiene**
- Bump parent POM `4.76 → 6.2153.vcf31911d10c4`
- Set `jenkins.baseline=2.555`, `jenkins.version=2.555.1`
- Switch BOM to `bom-${jenkins.baseline}.x` at `6398.v1d26a_dd495e2`
- Fix deprecated `git://` SCM URL
- Build matrix: linux + windows on JDK 21 (parent POM 6.x requires JDK 21
  to build, and Jenkins 2.555 ships Java 21 bytecode)
- Add Jenkins Security Scan reusable workflow
- Remove legacy `descriptor.getCheckUrl('id')` from `KsmCredential/config.jelly`

**Dependencies**
- Upgrade KSM core SDK `16.6.3 → 17.1.1`; adapt `KsmTestNotation` for the new
  `KeeperRecord` constructor (added `links` parameter)
- Drop `json-simple 1.1.1` (abandoned, CVE-2020-7712); consolidate on
  `org.json:json` and bump it `20231013 → 20250517`

**Bug fixes**
- `KsmBuildWrapper.systemSecretError` was an instance field never reset
  between builds, so a transient KSM error (e.g. 502, `transmission_key
  invalid`) survived on the wrapper until the job config was re-saved
- `KsmCommon.validFilePath` regex `^.:\\\\|/` rejected any path containing
  `/` due to operator precedence, blocking legitimate subdirectory paths
- `KsmCommon.validFilePath` parent-traversal walker used a `do/while` bound
  on `getParentFile() != null`, skipping the leftmost component and letting
  paths like `../escape` through

**Features**
- Notation now accepts a record title in place of a UID. The KSM SDK already
  resolved both; the plugin's parser was rejecting any token that wasn't
  exactly 22 characters. When all tokens look like UIDs we keep the
  server-side filter; otherwise we fetch all records and let the SDK resolve
  titles. Legacy UIDs starting with `-` continue to be classified as UIDs.

**Tests**
- 19 → 68 tests
- New `KsmCommonTest` (file path validation)
- New `KsmSecretTest` (validate, buildSecretName, isDestinationType)
- `KsmNotationTest` 1 → 27 tests (selector enum mapping, predicate parsing,
  error paths, leading-dash UIDs, title tokens)
- `KsmBuildWrapperTest` regression test for the cached-error bug
- `KsmStepTest` end-to-end pipeline run with a title-based notation

## Closes

- Closes #43 (record name in notation)
- Closes #50 (JENKINS-74514: legacy `checkUrl`)
- Closes #52 (cached bad response from Keeper)

## Supersedes

- Supersedes #44 (Snyk: KSM core 16.6.4 — covered by the 17.1.1 bump)
- Supersedes #45 (Jenkins Security Scan)
- Supersedes #46 (drop JDK 11)
- Supersedes #47 (jenkins.baseline)
- Supersedes #49 (Snyk: KSM core 17.1.1)

## Follow-ups (separate issues, not in this PR)

- #51 — `appOwnerPublicKey` support in `KsmCredential` / `KSM_CONFIG`. The
  SDK 17.1.1 bump unblocks this; will be addressed in a follow-up.
- #48 — Groovy API surface beyond the existing `withKsm` Pipeline step.
  Awaiting requester input on the desired surface.
- #10 — entropy/perf issue from 2022, addressed in plugin 1.0-76 and several
  SDK releases since. Will be closed as resolved unless reproduced on
  current Jenkins LTS with JDK 21.