### PR TITLE
Inline release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,107 @@
-_extends: .github
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+---
+name-template: $NEXT_MINOR_VERSION
+tag-template: $NEXT_MINOR_VERSION
+# Uses a more common 2-digit versioning in Jenkins plugins. Can be replaced by semver: $MAJOR.$MINOR.$PATCH
+version-template: $MAJOR.$MINOR
+
+# Emoji reference: https://gitmoji.carloscuesta.me/
+# If adding categories, please also update: https://github.com/jenkins-infra/jenkins-maven-cd-action/blob/master/action.yaml#L16
+categories:
+  - title: 💥 Breaking changes
+    labels:
+      - breaking
+  - title: 🚨 Removed
+    labels:
+      - removed
+  - title: 🎉 Major features and improvements
+    labels:
+      - major-enhancement
+      - major-rfe
+  - title: 🐛 Major bug fixes
+    labels:
+      - major-bug
+  - title: ⚠️ Deprecated
+    labels:
+      - deprecated
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+      - rfe
+  - title: 🐛 Bug fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+      - regression
+      - regression-fix
+  - title: 🌐 Localization and translation
+    labels:
+      - localization
+  - title: 👷 Changes for plugin developers
+    labels:
+      - developer
+  - title: 📝 Documentation updates
+    labels:
+      - documentation
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - internal
+      - maintenance
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
+  - title: ✍ Other changes
+  # Default label used by Dependabot
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
+    collapse-after: 15
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES
+
+replacers:
+  - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
+    replace: '[JENKINS-$1](https://issue-redirect.jenkins.io/issue/$1) - '
+  - search: '/\[*HELPDESK-(\d+)\]*\s*-*\s*/g'
+    replace: '[HELPDESK-$1](https://github.com/jenkins-infra/helpdesk/issues/$1) - '
+  # TODO(oleg_nenashev): Find a better way to reference issues
+  - search: '/\[*SECURITY-(\d+)\]*\s*-*\s*/g'
+    replace: '[SECURITY-$1](https://jenkins.io/security/advisories/) - '
+  - search: '/\[*JEP-(\d+)\]*\s*-*\s*/g'
+    replace: '[JEP-$1](https://github.com/jenkinsci/jep/tree/master/jep/$1) - '
+  - search: '/CVE-(\d{4})-(\d+)/g'
+    replace: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2'
+  - search: 'JFR'
+    replace: 'Jenkinsfile Runner'
+  - search: 'CWP'
+    replace: 'Custom WAR Packager'
+  - search: '@dependabot-preview'
+    replace: '@dependabot'
+
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    body:
+      - '/JENKINS-[0-9]{1,4}/'


### PR DESCRIPTION
Internal tracking: KSM-935.

Follow-up to #53. The single-line `_extends: .github` form in `.github/release-drafter.yml` is rejected by the release-drafter v6 action used by the maven-cd reusable workflow, which fails the validate step and sets  `should_release=false` so no release is ever published.
Inline the org-level config from `jenkinsci/.github` so the action can parse it directly.